### PR TITLE
Update dagger to 2.25.4

### DIFF
--- a/samples/github/build.gradle
+++ b/samples/github/build.gradle
@@ -85,11 +85,11 @@ dependencies {
     implementation 'com.apollographql.apollo:apollo-rx2-support:1.0.0-alpha5'
 
     // Dependency Injection
-    implementation 'com.google.dagger:dagger:2.20'
-    kapt 'com.google.dagger:dagger-compiler:2.20'
-    implementation 'com.google.dagger:dagger-android:2.20'
-    implementation 'com.google.dagger:dagger-android-support:2.20'
-    kapt 'com.google.dagger:dagger-android-processor:2.20'
+    implementation 'com.google.dagger:dagger:2.25.4'
+    kapt 'com.google.dagger:dagger-compiler:2.25.4'
+    implementation 'com.google.dagger:dagger-android:2.25.4'
+    implementation 'com.google.dagger:dagger-android-support:2.25.4'
+    kapt 'com.google.dagger:dagger-android-processor:2.25.4'
 
     // View
     implementation 'com.makeramen:roundedimageview:2.3.0'

--- a/samples/github/src/main/java/com/yuyakaido/android/reduxkit/sample/app/ReduxKit.kt
+++ b/samples/github/src/main/java/com/yuyakaido/android/reduxkit/sample/app/ReduxKit.kt
@@ -16,7 +16,7 @@ class ReduxKit : DaggerApplication() {
   lateinit var appStore: AppStore
 
   override fun applicationInjector(): AndroidInjector<out DaggerApplication> {
-    return DaggerAppComponent.builder().create(this)
+    return DaggerAppComponent.factory().create(this)
   }
 
   override fun onCreate() {

--- a/samples/github/src/main/java/com/yuyakaido/android/reduxkit/sample/di/component/AppComponent.kt
+++ b/samples/github/src/main/java/com/yuyakaido/android/reduxkit/sample/di/component/AppComponent.kt
@@ -18,7 +18,7 @@ import dagger.android.support.AndroidSupportInjectionModule
 )
 interface AppComponent : AndroidInjector<ReduxKit> {
 
-  @Component.Builder
-  abstract class Builder : AndroidInjector.Builder<ReduxKit>()
+  @Component.Factory
+  abstract class Factory : AndroidInjector.Factory<ReduxKit>
 
 }


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #1 

## 📝 関連する issue / Related Issues

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- daggerが`com.android.support`をサポートするバージョン[2.25.4](https://github.com/google/dagger/releases/tag/dagger-2.25.4)　にアップデート
- dagger2.22から `@Component.Factory`  が追加され、`@Component.Builder`が非推奨になったので `@Component.Factory` に変更

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->